### PR TITLE
Improved error handling when newWorld config is not set.

### DIFF
--- a/ronja_modules/NWDB.js
+++ b/ronja_modules/NWDB.js
@@ -41,25 +41,25 @@ const myNWDB = {
     },
 
     hookForCron: function() {
+        if (!this.cfg.newWorldChannel || !this.cfg.newWorldServer) {
+            console.info('INFO: newWorldChannel or newWorldServer not set in config file, disabling New-World queries!');
+            return [];
+        }
         return [
             {
                 schedule: this.cfg.newWorldCronPattern,
                 action: () => {
-                    if (this.cfg.newWorldChannel && this.cfg.newWorldServer) {
-                        this.client.channels.fetch(this.cfg.newWorldChannel)
-                        .then(c => {
-                            this.myGetServerStatus(this.cfg.newWorldServer)
-                            .then(res => {
-                                if (res != '') {
-                                    c.setTopic(res);
-                                }
-                            })
-                            .catch(console.error);
+                    this.client.channels.fetch(this.cfg.newWorldChannel)
+                    .then(c => {
+                        this.myGetServerStatus(this.cfg.newWorldServer)
+                        .then(res => {
+                            if (res != '') {
+                                c.setTopic(res);
+                            }
                         })
                         .catch(console.error);
-                    } else {
-                        console.warn('WARNING: newWorldServer and newWorldServer need to be set in config file!')
-                    }
+                    })
+                    .catch(console.error);
                 },
             }
         ];


### PR DESCRIPTION
Now it will only display one info message at server-start instead of a warning on every sheduled run.