### PR TITLE
Fix timezone config key casing (timeZone -> timezone)

### DIFF
--- a/ronja_modules/DynamicTextChannels.js
+++ b/ronja_modules/DynamicTextChannels.js
@@ -23,7 +23,7 @@ const myDynamicTextChannels = {
                 GameId: game.id,
                 lastplayed: {
                     [Op.gte]: DateTime.now()
-                        .setZone(this.cfg("timeZone"))
+                        .setZone(this.cfg("timezone"))
                         .minus({ days: pDays })
                         .toJSDate(),
                 },
@@ -43,7 +43,7 @@ const myDynamicTextChannels = {
             where: {
                 lastplayed: {
                     [Op.gte]: DateTime.now()
-                        .setZone(this.cfg("timeZone"))
+                        .setZone(this.cfg("timezone"))
                         .minus({ days: pDays })
                         .toJSDate(),
                 },

--- a/ronja_modules/Top10.js
+++ b/ronja_modules/Top10.js
@@ -43,7 +43,7 @@ const myTop10 = {
                     where: {
                         lastplayed: {
                             [Op.gte]: DateTime.now()
-                                .setZone(this.cfg("timeZone"))
+                                .setZone(this.cfg("timezone"))
                                 .minus({ days: pDays })
                                 .toJSDate(),
                         },

--- a/ronja_modules/Zocken.js
+++ b/ronja_modules/Zocken.js
@@ -181,7 +181,7 @@ const myZocken = {
                                 member: [interaction.member.id, channelMember.id],
                                 lastplayed: {
                                     [Op.gte]: DateTime.now()
-                                        .setZone(this.cfg("timeZone"))
+                                        .setZone(this.cfg("timezone"))
                                         .minus({ days: 100 })
                                         .toJSDate(),
                                 },
@@ -232,7 +232,7 @@ const myZocken = {
                 return;
             }
 
-            let startTime = DateTime.now().setZone(this.cfg("timeZone"));
+            let startTime = DateTime.now().setZone(this.cfg("timezone"));
 
             if (interaction.options.getString("time")) {
                 let regex = new RegExp(/(\d{2}):(\d{2})/);
@@ -263,7 +263,7 @@ const myZocken = {
 
                     startTime = DateTime.fromObject(
                         { hour: regexResult[1], minute: regexResult[2] },
-                        { zone: this.cfg("timeZone") }
+                        { zone: this.cfg("timezone") }
                     );
                 } else {
                     interaction.reply({


### PR DESCRIPTION
## Summary
- `this.cfg("timeZone")` (camelCase) returned `null` everywhere it was used, since the DB-backed setting is seeded as lowercase `"timezone"`. `DateTime...setZone(null)` silently falls back to UTC.
- Standardizes on the lowercase `"timezone"` key in `Zocken.js`, `Top10.js`, and `DynamicTextChannels.js`, matching `index.js` and the migration.

Fixes #48

## Test plan
- [ ] Set a non-UTC `timezone` setting and confirm `/top10`, the scheduled Top10 postings, and Zocken's game-session start-time embeds render in that timezone instead of UTC.