### PR TITLE
Fix Top10 weekly/monthly/yearly toggles ignoring "false"

### DIFF
--- a/ronja_modules/Top10.js
+++ b/ronja_modules/Top10.js
@@ -111,21 +111,21 @@ const myTop10 = {
             {
                 schedule: "0 8 * * 1",
                 action: () => {
-                    if (this.cfg("top10Weekly"))
+                    if (this.cfg("top10Weekly") === "true")
                         this.postTop10ToChannel(7, "The most played games of last week:");
                 },
             },
             {
                 schedule: "0 7 1 * *",
                 action: () => {
-                    if (this.cfg("top10Monthly"))
+                    if (this.cfg("top10Monthly") === "true")
                         this.postTop10ToChannel(30, "The most played games of last month:");
                 },
             },
             {
                 schedule: "0 0 1 1 *",
                 action: () => {
-                    if (this.cfg("top10Yearly"))
+                    if (this.cfg("top10Yearly") === "true")
                         this.postTop10ToChannel(
                             365,
                             "Happy new year! These have been the highlights of last year:"


### PR DESCRIPTION
## Summary
- `top10Weekly`/`top10Monthly`/`top10Yearly` settings are stored as the strings `"true"`/`"false"`, but were checked with plain truthiness (`if (this.cfg("top10Weekly"))`) — a non-empty `"false"` string is always truthy, so disabling a toggle had no effect.
- Now compares explicitly against the string `"true"`.

Fixes #49

## Test plan
- [ ] Set `top10Weekly` to `"false"` via `myConfigSet` and confirm the weekly cron no longer posts.
- [ ] Set it back to `"true"` and confirm posting resumes.