### PR TITLE
Coerce voiceChannelBitrate to a number before sending to Discord

### DIFF
--- a/ronja_modules/DynamicVoiceChannels.js
+++ b/ronja_modules/DynamicVoiceChannels.js
@@ -39,7 +39,7 @@ const myDynamicVoiceChannels = {
             let newChannel = await newState.channel.parent.children.create({
                 name: `Kanal von ${newState.member.displayName}`,
                 type: ChannelType.GuildVoice,
-                bitrate: this.cfg("voiceChannelBitrate"),
+                bitrate: Number(this.cfg("voiceChannelBitrate")),
             });
             newChannel.lockPermissions();
             try {


### PR DESCRIPTION
## Summary
- `voiceChannelBitrate` moved from a hardcoded numeric default to a DB `Setting` (STRING column), so `this.cfg("voiceChannelBitrate")` now returns `"96000"` rather than `96000`.
- `DynamicVoiceChannels.js` passed that string straight through as the `bitrate` option when creating a new voice channel in the "create new channel" slot flow. Coerced with `Number(...)` at the call site.

Fixes #51

## Test plan
- [ ] Join the "create new channel" voice slot and confirm the created channel's bitrate matches the configured `voiceChannelBitrate` setting without API errors.