### PR TITLE
Handle Discord's 50-channels-per-category limit in DynamicTextChannels

### DIFF
--- a/core/Ronja.js
+++ b/core/Ronja.js
@@ -69,6 +69,16 @@ class Ronja extends Client {
         });
     }
 
+    async myNotifyOwner(guild, message) {
+        console.error(message);
+        try {
+            let owner = await guild.fetchOwner();
+            await owner.send(message);
+        } catch (err) {
+            console.error(`Could not DM the guild owner: ${err}`);
+        }
+    }
+
     myTranslator() {
         if (this.myLanguage[arguments[0]] && this.myLanguage[arguments[0]][arguments[1]]) {
             arguments[1] =

--- a/core/language_de.json
+++ b/core/language_de.json
@@ -92,5 +92,14 @@
     "Could not be safed. Maybe the bot is missing some permissions?": [
         "Could not be safed. Maybe the bot is missing some permissions?"
     ],
-    "Language of the guild was changed to %s.": ["Serversprache wurde auf %s geändert."]
+    "Language of the guild was changed to %s.": ["Serversprache wurde auf %s geändert."],
+    "Could not create a text channel for %s: category #%s has reached Discord's limit of 50 channels.": [
+        "Konnte keinen Textkanal für %s erstellen: Die Kategorie #%s hat Discords Limit von 50 Kanälen erreicht."
+    ],
+    "Could not move #%s to the archive category #%s: it has reached Discord's limit of 50 channels.": [
+        "Konnte #%s nicht in die Archiv-Kategorie #%s verschieben: Sie hat Discords Limit von 50 Kanälen erreicht."
+    ],
+    "Could not move #%s back to the active category #%s: it has reached Discord's limit of 50 channels.": [
+        "Konnte #%s nicht zurück in die aktive Kategorie #%s verschieben: Sie hat Discords Limit von 50 Kanälen erreicht."
+    ]
 }

--- a/ronja_modules/DynamicTextChannels.js
+++ b/ronja_modules/DynamicTextChannels.js
@@ -90,16 +90,6 @@ const myDynamicTextChannels = {
         }
     },
 
-    notifyOwner: async function (guild, message) {
-        console.error(message);
-        try {
-            let owner = await guild.fetchOwner();
-            await owner.send(message);
-        } catch (err) {
-            console.error(`Could not DM the guild owner: ${err}`);
-        }
-    },
-
     notifyChannel: async function (myTitle, myDescription) {
         if (this.cfg("dtcNotificationChannel")) {
             this.client.channels
@@ -128,7 +118,7 @@ const myDynamicTextChannels = {
                 });
             } catch (err) {
                 if (err.code !== RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached) throw err;
-                this.notifyOwner(
+                this.client.myNotifyOwner(
                     newPresence.guild,
                     this.l(
                         newPresence.guild.preferredLocale,
@@ -170,7 +160,7 @@ const myDynamicTextChannels = {
                 } catch (err) {
                     if (err.code !== RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached)
                         throw err;
-                    this.notifyOwner(
+                    this.client.myNotifyOwner(
                         channel.guild,
                         this.l(
                             channel.guild.preferredLocale,
@@ -205,7 +195,7 @@ const myDynamicTextChannels = {
                         } catch (err) {
                             if (err.code !== RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached)
                                 throw err;
-                            this.notifyOwner(
+                            this.client.myNotifyOwner(
                                 gameChannel.guild,
                                 this.l(
                                     gameChannel.guild.preferredLocale,

--- a/ronja_modules/DynamicTextChannels.js
+++ b/ronja_modules/DynamicTextChannels.js
@@ -1,4 +1,10 @@
-const { ChannelType, PermissionFlagsBits, EmbedBuilder, Colors } = require("discord.js");
+const {
+    ChannelType,
+    PermissionFlagsBits,
+    EmbedBuilder,
+    Colors,
+    RESTJSONErrorCodes,
+} = require("discord.js");
 const { DateTime } = require("luxon");
 const Sequelize = require("sequelize");
 const Op = Sequelize.Op;
@@ -84,6 +90,16 @@ const myDynamicTextChannels = {
         }
     },
 
+    notifyOwner: async function (guild, message) {
+        console.error(message);
+        try {
+            let owner = await guild.fetchOwner();
+            await owner.send(message);
+        } catch (err) {
+            console.error(`Could not DM the guild owner: ${err}`);
+        }
+    },
+
     notifyChannel: async function (myTitle, myDescription) {
         if (this.cfg("dtcNotificationChannel")) {
             this.client.channels
@@ -103,11 +119,26 @@ const myDynamicTextChannels = {
     createTextChannel: async function (game, newActivity, newPresence) {
         if (this.cfg("dtcGamesCategory")) {
             let dtcGamesCategory = await this.client.channels.fetch(this.cfg("dtcGamesCategory"));
-            let newChannel = await dtcGamesCategory.children.create({
-                name: newActivity.name,
-                type: ChannelType.GuildText,
-                permissionOverwrites: await this.defaultOverrides(newPresence.guild),
-            });
+            let newChannel;
+            try {
+                newChannel = await dtcGamesCategory.children.create({
+                    name: newActivity.name,
+                    type: ChannelType.GuildText,
+                    permissionOverwrites: await this.defaultOverrides(newPresence.guild),
+                });
+            } catch (err) {
+                if (err.code !== RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached) throw err;
+                this.notifyOwner(
+                    newPresence.guild,
+                    this.l(
+                        newPresence.guild.preferredLocale,
+                        "Could not create a text channel for %s: category #%s has reached Discord's limit of 50 channels.",
+                        newActivity.name,
+                        dtcGamesCategory.name
+                    )
+                );
+                return;
+            }
 
             this.assignAllPlayersToChannel(newChannel, game, this.cfg("dtcDaysTarget"));
             game.update({ channel: newChannel.id });
@@ -134,7 +165,22 @@ const myDynamicTextChannels = {
                 let dtcArchivedGamesCategory = await this.client.channels.fetch(
                     this.cfg("dtcArchivedGamesCategory")
                 );
-                channel.setParent(dtcArchivedGamesCategory);
+                try {
+                    await channel.setParent(dtcArchivedGamesCategory);
+                } catch (err) {
+                    if (err.code !== RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached)
+                        throw err;
+                    this.notifyOwner(
+                        channel.guild,
+                        this.l(
+                            channel.guild.preferredLocale,
+                            "Could not move #%s to the archive category #%s: it has reached Discord's limit of 50 channels.",
+                            channel.name,
+                            dtcArchivedGamesCategory.name
+                        )
+                    );
+                    return;
+                }
                 channel.permissionOverwrites.set(await this.defaultOverrides(channel.guild));
 
                 console.log(`Moved #${channel.name} to archive.`);
@@ -154,7 +200,22 @@ const myDynamicTextChannels = {
                         let dtcGamesCategory = await this.client.channels.fetch(
                             this.cfg("dtcGamesCategory")
                         );
-                        gameChannel.setParent(dtcGamesCategory);
+                        try {
+                            await gameChannel.setParent(dtcGamesCategory);
+                        } catch (err) {
+                            if (err.code !== RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached)
+                                throw err;
+                            this.notifyOwner(
+                                gameChannel.guild,
+                                this.l(
+                                    gameChannel.guild.preferredLocale,
+                                    "Could not move #%s back to the active category #%s: it has reached Discord's limit of 50 channels.",
+                                    gameChannel.name,
+                                    dtcGamesCategory.name
+                                )
+                            );
+                            return;
+                        }
                         await gameChannel.permissionOverwrites.set(
                             await this.defaultOverrides(gameChannel.guild)
                         );


### PR DESCRIPTION
## Summary
- Three places call the Discord API without handling a full category (Discord's hard limit of 50 channels per category, `RESTJSONErrorCodes.MaximumNumberOfGuildChannelsReached`):
  - `createTextChannel` — creating a new game channel in `dtcGamesCategory`.
  - `checkActiveTextChannel` — moving a channel to `dtcArchivedGamesCategory`.
  - `hookForStartedPlaying`'s reactivation branch — moving a channel back to `dtcGamesCategory`.
- Along the way, fixed two of those `setParent(...)` calls not being `await`ed at all, which meant errors from them were previously unhandled/silent rather than just uncaught.
- Added `myNotifyOwner` on the `Ronja` client (`core/Ronja.js`, following the existing `my*` naming convention alongside `myConfigGet`/`myConfigSet`/`myTranslator`) rather than as a module-local helper, since DMing the guild owner about a failure is generic enough to be useful from other modules later. On a category-limit error, the guild owner now gets a DM explaining which category is full and what operation couldn't complete, instead of the failure only showing up in the bot's own logs (or not at all, given the missing `await`s). Any other error is rethrown unchanged.
- Added German translations for the three new user-facing strings in `core/language_de.json`, matching this repo's existing convention of translating every string rather than leaving it on the auto-seeded fallback.

Fixes #46

## Test plan
- [ ] Fill a test category to 50 channels, then trigger channel creation (new game played by enough members) and confirm the guild owner receives a DM instead of a crash/silent failure.
- [ ] Same for archiving a channel and for reactivating an archived channel back to a full active category.
- [ ] Confirm normal (non-full-category) create/archive/reactivate flows still work unchanged.