### PR TITLE
Handle manually deleted game channels gracefully

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ Discord gateway events in `index.js` are fanned out to _every_ module by checkin
 
 - `hookForCommandInteraction`, `hookForContextMenuInteraction`, `hookForButtonInteraction` — from `Events.InteractionCreate`
 - `hookForVoiceUpdate` — from `Events.VoiceStateUpdate`
+- `hookForChannelDelete` — from `Events.ChannelDelete`
 - `hookForEventUserAdd` / `hookForEventUserRemove` / `hookForEventUserUpdate` — from `Events.GuildScheduledEventUserAdd`/`Remove`
 - `hookForEventUpdate` — from `Events.GuildScheduledEventUpdate`
 - `hookForEventStart` — from `Events.GuildScheduledEventUpdate` when status transitions into `Active`

--- a/index.js
+++ b/index.js
@@ -103,6 +103,13 @@ client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
     });
 });
 
+// Listen for ChannelDelete and forward to all modules
+client.on(Events.ChannelDelete, async (channel) => {
+    ronja_modules.forEach((m) => {
+        if (m.hookForChannelDelete) m.hookForChannelDelete(channel);
+    });
+});
+
 // Listen for GuildScheduledEventUserAdd and forward to all modules
 client.on(Events.GuildScheduledEventUserAdd, async (oGuildScheduledEvent, oUser) => {
     ronja_modules.forEach((m) => {

--- a/ronja_modules/DynamicTextChannels.js
+++ b/ronja_modules/DynamicTextChannels.js
@@ -183,8 +183,20 @@ const myDynamicTextChannels = {
     hookForStartedPlaying: async function (oldPresence, newPresence, newActivity, game) {
         if (this.cfg("dtcArchivedGamesCategory")) {
             // TODO: Check if member has access right for parent-category dtcGamesCategory
+            let gameChannel = null;
             if (game.channel) {
-                let gameChannel = await this.client.channels.fetch(game.channel);
+                try {
+                    gameChannel = await this.client.channels.fetch(game.channel);
+                } catch (err) {
+                    if (err.code !== RESTJSONErrorCodes.UnknownChannel) throw err;
+                    // Someone deleted the channel manually (e.g. while the bot was offline, so
+                    // hookForChannelDelete never ran for it). Forget it and fall through to the
+                    // same path as a game that never had a channel.
+                    await game.update({ channel: null });
+                }
+            }
+
+            if (gameChannel) {
                 if (gameChannel.parentId == this.cfg("dtcArchivedGamesCategory")) {
                     if ((await this.countPlayersForGame(game, this.cfg("dtcDaysTarget"))) > 1) {
                         let dtcGamesCategory = await this.client.channels.fetch(
@@ -248,6 +260,16 @@ const myDynamicTextChannels = {
             }
         } else {
             console.warn("WARNING: no dtcArchivedGamesCategory set in config file!");
+        }
+    },
+
+    hookForChannelDelete: async function (channel) {
+        let game = await this.client.db.Game.findOne({ where: { channel: channel.id } });
+        if (game) {
+            await game.update({ channel: null });
+            console.log(
+                `Cleared deleted game channel #${channel.name} (${channel.id}) from the database.`
+            );
         }
     },
 

--- a/ronja_modules/Example.js
+++ b/ronja_modules/Example.js
@@ -59,6 +59,11 @@ const myExample = {
         console.debug("The voice status of a user has updated!");
     },
 
+    hookForChannelDelete: async function (channel) {
+        // https://discord.js.org/#/docs/discord.js/stable/class/GuildChannel
+        console.debug("A channel has been deleted!");
+    },
+
     hookForEventUpdate: async function (oldGuildScheduledEvent, newGuildScheduledEvent) {
         // https://discord.js.org/#/docs/discord.js/stable/class/GuildScheduledEvent
         console.debug("A scheduled guild event has been updated!");


### PR DESCRIPTION
## Summary

Deleting a game's text channel manually could crash the entire bot process, not just misbehave locally. The chain:

- `Game.channel` (a stored channel ID) is only ever consumed in one place: `DynamicTextChannels.js`'s `hookForStartedPlaying`, which unconditionally does `this.client.channels.fetch(game.channel)`.
- If that channel was deleted, Discord returns `Unknown Channel` (`RESTJSONErrorCodes.UnknownChannel`, 10003), which `channels.fetch` surfaces as a rejected promise.
- `index.js` calls `hookForStartedPlaying` from its `PresenceUpdate` handler without `await` or `.catch(...)` (`ronja_modules.forEach((m) => { if (m.hookForStartedPlaying) m.hookForStartedPlaying(...); })`), and there's no global `unhandledRejection`/`uncaughtException` handler anywhere in the codebase.
- On Node.js (this repo runs on a recent version), an unhandled promise rejection terminates the process by default. So the very next time anyone plays a game whose channel got deleted, the whole bot goes down.

## Changes
- `hookForStartedPlaying` now catches `UnknownChannel` specifically, clears the stale `channel` ID on the `Game` row, and falls through to the same code path as a game that never had a channel — so a replacement channel gets created immediately if enough people are still playing, instead of the game being stuck channel-less until next restart.
- Added a `hookForChannelDelete` hook (new `Events.ChannelDelete` fan-out in `index.js`, documented in `CLAUDE.md`) so `DynamicTextChannels` clears a `Game`'s `channel` ID the moment the channel is deleted while the bot is online, rather than only noticing reactively on the next presence update.
- Other errors from the fetch are rethrown unchanged.

I checked for other places a deleted game channel could cause problems: `Game.channel` is read/written *only* in `DynamicTextChannels.js` (verified via a full-codebase grep), so this is the single point that needed guarding. The cron-driven `checkActiveTextChannel` path iterates live `category.children.cache` entries rather than a possibly-stale stored ID, so it isn't affected by this failure mode.

Fixes #19

## Test plan
- [ ] Manually delete an active game channel while the bot is running; confirm the console logs the cleanup and the bot doesn't crash.
- [ ] Have enough members start playing that same game again; confirm a new channel gets created instead of the game staying channel-less.
- [ ] Delete a game channel while the bot is offline, then restart and have someone play that game; confirm the stale ID is cleared and a new channel is created, with no crash.